### PR TITLE
Support React 14 and 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "collapse-white-space": "^1.0.0",
-    "react": "^0.14.7",
+    "react": "^0.14.7 || ^15.0.0-rc.1",
     "react-element-to-jsx-string": "^2.4.0"
   },
   "repository": "algolia/expect-jsx",


### PR DESCRIPTION
Adds support for React 15: http://facebook.github.io/react/blog/2016/03/07/react-v15-rc1.html

See: https://github.com/algolia/react-element-to-jsx-string/pull/19