### PR TITLE
Update react-element-to-jsx-string to 3.0.0 to support react 15.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "collapse-white-space": "^1.0.0",
     "react": "^0.14.8 || ^15.0.1",
-    "react-element-to-jsx-string": "^2.6.1"
+    "react-element-to-jsx-string": "^3.0.0"
   },
   "repository": "algolia/expect-jsx",
   "keywords": [


### PR DESCRIPTION
After attempting to update to the latest `React 15.1.0` release, errors were causing the install to fail.  

This was due to `react-element-to-jsx-string 2.6.1` having a dependency on `React 0.14.8`.

```
npm ERR! peerinvalid The package react does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer react-element-to-jsx-string@2.6.1 wants react@^0.14.8 || ^15.0.1
```

Updating to `react-element-to-jsx-string ^3.0.0` resolves this issue.